### PR TITLE
Create Ambiguity_resolution.cpp

### DIFF
--- a/Ambiguity_resolution.cpp
+++ b/Ambiguity_resolution.cpp
@@ -1,0 +1,37 @@
+#include<iostream>
+using namespace std;
+
+class Base1
+{
+  public:
+  void hello(void)
+  {
+    cout << "Hello from Base1 class" << endl;
+  }
+};
+
+class Base2
+{
+  public:
+  void hello(void)
+  {
+    cout << "Namaskar from Base2 class " << endl;
+  }
+};
+
+class Derived : public Base1, public Base2 
+{
+    public:
+    void hello(void)
+    {
+    Base2::hello();
+    }
+};
+
+// as you can see here there are two classes Base1 and Base2 both are having same function hello this create the ambiguity.
+
+int main()
+{
+  Derived d;
+  d.hello();
+}


### PR DESCRIPTION
from the above code we have resolved the ambiguity from inheritance!

when one class is derived for two or more base classes then there are chances that the base classes have functions with the same name. So it will confuse derived class to choose from similar name functions. To solve this ambiguity scope resolution operator is used “::”. An example program is shown below to demonstrate the concept of ambiguity resolution in inheritance.